### PR TITLE
Binder fix

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -ex
+
 pip install .

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ description = "VolFe"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [
-    { name = "Ery Hughes, Pip Liggins, Penny Wieser", email = "ery.c.hughes@gmail.com" },
+    {name = "Ery Hughes", email = "ery.c.hughes@gmail.com"},
+    {name = "Pip Liggins"},
+    {name = "Penny Wieser"}
 ]
 classifiers = [
     "Operating System :: OS Independent",


### PR DESCRIPTION
Possible fix for binder notebooks not working - binder doesn't recognise pyproject.toml, so need to add a postBuild script to force it to load VolFe (and dependencies).

Alternative is to add a requirements.txt file in the .binder file, but would then have to be careful not to let the two dependencies lists (in pyproject.toml and binder/requirements.txt) not to get out of synch.